### PR TITLE
expose warning from stderr for "service check"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 18, 19]
+        node-version: [16, 18, 19, 20]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/src/check.js
+++ b/src/check.js
@@ -110,8 +110,12 @@ const getOwnPorts = () =>
     ps.push('ps', '-q')
 
     exec(`docker-compose ${ps.join(' ')}`, function (err, stdout, stderr) {
-      if (err || stderr.toString().trim()) {
+      if (err) {
         return reject(err)
+      }
+
+      if (stderr.toString().trim()) {
+        return reject(stderr.toString().trim())
       }
 
       const ids = stdout.split('\n').filter((id) => id)


### PR DESCRIPTION
check command was reporting errors only from `err` and missed rejecting with stderr. This led to an missleading exception like:

```bash
❯ service check
file:///[...]/node_modules/@uscreen.de/dev-service/src/utils.js:114
  console.error(chalk.red(`ERROR: ${e.message}\n`))
```

instead of reporting the error (or warning in this case):

```bash
❯ service check
time="2023-06-10T18:02:07+02:00" level=warning msg="volume mongo-data: volume.external.name is deprecated in favor of volume.name"
ERROR: undefined
```

unfortunately I still have issues passing all tests on my dev with 

- Docker version 23.0.5, build bc4487a
- Docker Compose version v2.17.3

If CI passes, I could publish a pre-release or hotfix. 